### PR TITLE
Update installation instructions for pypi world (GEN-1001)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,24 +37,22 @@ jobs:
       uses: snok/install-poetry@v1
       with:
         version: 1.8.3
-    - id: auth
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: "${{ secrets.ARTIFACT_REGISTRY_KEY }}"
-    - name: Deploy key config
-      run: |
-        poetry self add keyrings.google-artifactregistry-auth
-        poetry config repositories.gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/
+
     - name: Python deps (via poetry)
       run: poetry install
+
     - name: Kernel install
       run: poetry run python -m ipykernel install --user --name genstudio
+
     - name: mkdocs build
       run: poetry run mkdocs build
+
     - name: Copy llms.py to site
       run: cp docs/llms.py ./site/
+
     - name: Setup Pages
       uses: actions/configure-pages@v5
+
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -16,18 +16,8 @@ jobs:
         with:
           python-version: 3.11.5
 
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: "${{ secrets.ARTIFACT_REGISTRY_KEY }}"
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
-
-      - run: poetry self update && poetry self add keyrings.google-artifactregistry-auth
 
       - run: poetry install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,16 +34,6 @@ jobs:
         with:
           version: 1.8.3
 
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: "${{ secrets.ARTIFACT_REGISTRY_KEY }}"
-
-      - name: Configure Poetry
-        run: |
-          poetry self add keyrings.google-artifactregistry-auth
-          poetry config repositories.gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/
-
       - name: Install Python dependencies
         run: poetry install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,27 +14,14 @@ Key features:
 
 ### Installation
 
-!!! note
-    GenStudio is currently private. To configure your machine to access the package,
-    - Run `\invite-genjax <google-account-email>` in any channel in the the probcomp Slack, or [file a ticket requesting access to the GenJAX-Users
-    group](https://github.com/probcomp/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
-    - [install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install)
-    - follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
-    - run `gcloud auth application-default login` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
-
-If you're using [GenJAX](https://www.github.com/probcomp/genjax) and have already followed the [installation instructions](https://genjax.gen.dev/#quickstart), you can add `genstudio` as an "extra" while installing GenJAX: `genjax[genstudio]`.
-
-To install GenStudio using `pip`:
+To install GenStudio, run
 
 ```bash
-pip install keyring keyrings.google-artifactregistry-auth
-pip install genstudio --extra-index-url https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
+pip install genstudio
 ```
 
-If you're using `poetry`:
+If you're using [GenJAX](https://genjax.gen.dev), you can install GenStudio as an extra:
 
 ```bash
-poetry self update && poetry self add keyrings.google-artifactregistry-auth
-poetry source add --priority=explicit gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
-poetry add genstudio --source gcp
+pip install genjax[genstudio]
 ```


### PR DESCRIPTION
This PR:

- simplifies the installation instructions
- removes any remaining gcloud auth from the GitHub Actions workflows